### PR TITLE
[DUTYMATE-190] fix: Add www.dutymate.net to CORS allowed origins

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!-- MR 제목은 다음을 참고해서 작성해주세요.
+[#issue] type: Short (50 chars or less) summary of changes
+ex. [S12P11A108-1] feat: Summarize changes in around 50 characters or less 
+-->
+
+## ➕ 연관된 이슈
+<!-- GitLab Issues나 Jira 등 관련된 이슈를 작성해주세요.-->
+<!-- GitLab Issues: Fixes #issue -->
+<!-- Jira: S12P11A108-number -->
+
+## 🔎 변경 사항
+<!-- 변경 사항에 대해 설명해주세요. -->
+
+## 🖼️ 이미지 첨부 (선택)
+<!--<img src="파일 주소" width="30%" height="30%"/> -->
+
+## 🛠️ 의존성 변경
+<!-- 새로 추가한 의존성이 있다면 작성해주세요. -->
+<!-- 만약 없다면, N/A라고 작성해주세요. -->
+
+```
+- Frontend / Backend 명시
+- 라이브러리 : N/A
+```
+
+## 📚 참고사항 혹은 궁금한 사항
+<!-- 리뷰어가 참고해야 할 사항이 있거나 궁금한 사항이 있는 경우 작성해주세요.
+(ex. react-query 라이브러리를 추가했습니다. pull 받으신 후에 npm i / yarn 입력해주세요.)
+(ex. query를 어떻게 사용해야 하는지 모르겠습니다. 방법 좀 공유해주세요.) 
+(ex. table join SQL문을 어떻게 작성해야하는지 모르겠습니다. 참고한 링크 공유합니다. -->
+
+```
+
+```

--- a/backend/src/main/java/net/dutymate/api/global/config/WebConfig.java
+++ b/backend/src/main/java/net/dutymate/api/global/config/WebConfig.java
@@ -35,7 +35,7 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOriginPatterns("http://localhost:5173", "https://dutymate.net")
+			.allowedOriginPatterns("http://localhost:5173", "https://dutymate.net", "https://www.dutymate.net")
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
 			.allowedHeaders("*")
 			.allowCredentials(true)


### PR DESCRIPTION
## ➕ 연관된 이슈
DUTYMATE-190

## 🔎 변경 사항
- `www.dutymate.net` 도메인으로 접근 시 발생하던 CORS 에러 수정
- WebConfig의 allowedOriginPatterns에 `https://www.dutymate.net` 추가
- PR Template을 추가했습니다.

## 🖼️ 이미지 첨부 (선택)
N/A