### PR TITLE
[#DUTYMATE-187] feat: Block temp login and move password to env

### DIFF
--- a/backend/src/main/java/net/dutymate/api/domain/ward/service/WardService.java
+++ b/backend/src/main/java/net/dutymate/api/domain/ward/service/WardService.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -63,6 +65,9 @@ public class WardService {
 
 	private final ShiftUtil shiftUtil;
 	private final S3Service s3Service;
+
+	@Value("${temp.nurse.password}")
+	private String tempNursePassword;
 
 	@Transactional
 	public void createWard(WardRequestDto requestWardDto, Member member) {
@@ -488,7 +493,7 @@ public class WardService {
 			Member virtualMember = Member.builder()
 				.email(MemberService.TEMP_NURSE_EMAIL)
 				.name(virtualNurseName)
-				.password("tempPassword123!!")
+				.password(BCrypt.hashpw(tempNursePassword, BCrypt.gensalt()))
 				.grade(1)
 				.role(Role.RN)
 				.gender(Gender.F)

--- a/backend/src/main/resources/application-env.yaml
+++ b/backend/src/main/resources/application-env.yaml
@@ -117,3 +117,8 @@ app:
 
 admin:
   email: ${ADMIN_EMAIL}
+
+# 템프(가상 간호사) 계정 비밀번호 (로그인 불가, 신규 생성 시에만 사용). .env에 TEMP_NURSE_PASSWORD 설정 필수.
+temp:
+  nurse:
+    password: ${TEMP_NURSE_PASSWORD}


### PR DESCRIPTION
<!-- PR 제목 (위에 따로 입력)
[#DUTYMATE-187] feat: Block temp login and move password to env
-->

## ➕ 연관된 이슈
- DUTYMATE-187 [공통] 템프 계정 로그인 예외 처리를 적용하라

## 🔎 변경 사항

### 문제
- `tempEmail@temp.com` 템프 계정이 5000건 이상 동일 이메일로 존재하여, 로그인 시 `findMemberByEmail` 쿼리 실패(다중 결과 등)로 500 에러 발생

### 조치
1. **템프 계정 로그인 차단**
   - 로그인 시 이메일이 `tempEmail@temp.com`이면 DB 조회 전에 차단
   - 기존과 동일한 사용자 메시지 반환: `"아이디 또는 비밀번호 오류입니다."`
   - 로그인 로그에는 "템프 계정 로그인 시도"로 기록

2. **템프 계정 비밀번호를 .env로 이전**
   - `application-env.yaml`에 `temp.nurse.password: ${TEMP_NURSE_PASSWORD}` 추가 (기본값 제거, 보안상 필수 설정)
   - `MemberService`, `WardService`에서 템프 계정 생성 시 위 설정값 사용
   - DB 저장 시 **BCrypt 해시** 후 저장 (일반 회원과 동일: `SignUpRequestDto.toMember()`, `Member.updatePassword()`)

### 배포 시
- **`.env`에 `TEMP_NURSE_PASSWORD=원하는비밀번호` 설정 확인 필요**

## 🖼️ 이미지 첨부 (선택)
N/A

## 🛠️ 의존성 변경
```
- Backend: .env 업데이트
- Frontend: N/A
```

## 📚 참고사항 혹은 궁금한 사항
- 템프 계정은 로그인 불가이며, 비밀번호는 신규 템프(가상 간호사) 계정 생성 시에만 사용됩니다.
